### PR TITLE
fix adv assline drain from wrong input hatch

### DIFF
--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -735,7 +735,7 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
 
     private void drainAllFluids(GT_Recipe.GT_Recipe_AssemblyLine recipe) {
         for (int i = 0; i < recipe.mFluidInputs.length; i++) {
-            depleteInput(recipe.mFluidInputs[i]);
+            mInputHatches.get(i).drain(ForgeDirection.UNKNOWN, recipe.mFluidInputs[i], true);
         }
     }
 


### PR DESCRIPTION
assline drain from matching input hatch only, whereas adv assline might drain from prior input hatches if they are quad input hatch.