### PR TITLE
make gt tool to be selected by ae2 nei handler

### DIFF
--- a/src/main/java/net/glease/ggfab/GigaGramFab.java
+++ b/src/main/java/net/glease/ggfab/GigaGramFab.java
@@ -1,14 +1,21 @@
 package net.glease.ggfab;
 
+import java.util.stream.IntStream;
+
 import static gregtech.api.enums.ToolDictNames.*;
 import static gregtech.common.items.GT_MetaGenerated_Tool_01.*;
 import static net.glease.ggfab.api.GGFabRecipeMaps.toolCastRecipes;
 
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.TierEU;
+import gregtech.api.util.GT_RecipeConstants;
 import net.glease.ggfab.api.GigaGramFabAPI;
 import net.glease.ggfab.items.GGMetaItem_DumbItems;
 import net.glease.ggfab.mte.MTE_AdvAssLine;
 import net.glease.ggfab.mte.MTE_LinkedInputBus;
 import net.glease.ggfab.util.GGUtils;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import cpw.mods.fml.common.Mod;
@@ -29,6 +36,7 @@ import gregtech.api.util.GT_ProcessingArray_Manager;
         acceptedMinecraftVersions = "[1.7.10]",
         dependencies = "required-after:IC2;required-before:gregtech")
 public class GigaGramFab {
+    public static GGMetaItem_DumbItems DUMB_ITEM_1;
 
     public GigaGramFab() {
         // initialize the textures
@@ -39,6 +47,7 @@ public class GigaGramFab {
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
         GregTech_API.sAfterGTPreload.add(() -> {
+            initDumbItem1();
             GGItemList.AdvAssLine.set(
                     new MTE_AdvAssLine(13532, "ggfab.machine.adv_assline", "Advanced Assembly Line").getStackForm(1));
             GGItemList.LinkedInputBus.set(
@@ -122,7 +131,7 @@ public class GigaGramFab {
         GregTech_API.sBeforeGTPostload.add(new SingleUseToolRecipeLoader());
         ConfigurationHandler.INSTANCE.init(event.getSuggestedConfigurationFile());
 
-        initDumbItem1();
+        DUMB_ITEM_1 = new GGMetaItem_DumbItems("ggfab.d1");
     }
 
     @Mod.EventHandler
@@ -132,7 +141,6 @@ public class GigaGramFab {
     public void postInit(FMLPostInitializationEvent event) {}
 
     private void initDumbItem1() {
-        GGMetaItem_DumbItems i1 = new GGMetaItem_DumbItems("ggfab.d1");
         int id = 0;
         {
             int idShape = 30;
@@ -142,7 +150,7 @@ public class GigaGramFab {
             for (GGItemList i : GGItemList.values()) {
                 ItemStack stack = null;
                 if (i.name().startsWith(prefix)) {
-                    stack = i1.addItem(
+                    stack = DUMB_ITEM_1.addItem(
                             id++,
                             "Single Use "
                                     + GGUtils.processSentence(i.name().substring(prefix.length()), ' ', true, true),
@@ -150,7 +158,7 @@ public class GigaGramFab {
                             i,
                             i.name().substring("One_Use_".length()));
                 } else if (i.name().startsWith(prefix2)) {
-                    stack = i1.addItem(
+                    stack = DUMB_ITEM_1.addItem(
                             idShape++,
                             "Tool Casting Mold ("
                                     + GGUtils.processSentence(i.name().substring(prefix2.length()), ' ', true, true)

--- a/src/main/java/net/glease/ggfab/GigaGramFab.java
+++ b/src/main/java/net/glease/ggfab/GigaGramFab.java
@@ -1,21 +1,14 @@
 package net.glease.ggfab;
 
-import java.util.stream.IntStream;
-
 import static gregtech.api.enums.ToolDictNames.*;
 import static gregtech.common.items.GT_MetaGenerated_Tool_01.*;
 import static net.glease.ggfab.api.GGFabRecipeMaps.toolCastRecipes;
 
-import gregtech.api.enums.GT_Values;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.TierEU;
-import gregtech.api.util.GT_RecipeConstants;
 import net.glease.ggfab.api.GigaGramFabAPI;
 import net.glease.ggfab.items.GGMetaItem_DumbItems;
 import net.glease.ggfab.mte.MTE_AdvAssLine;
 import net.glease.ggfab.mte.MTE_LinkedInputBus;
 import net.glease.ggfab.util.GGUtils;
-import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import cpw.mods.fml.common.Mod;
@@ -36,6 +29,7 @@ import gregtech.api.util.GT_ProcessingArray_Manager;
         acceptedMinecraftVersions = "[1.7.10]",
         dependencies = "required-after:IC2;required-before:gregtech")
 public class GigaGramFab {
+
     public static GGMetaItem_DumbItems DUMB_ITEM_1;
 
     public GigaGramFab() {


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15149 by reverting to previous behavior.

HOWEVER, it's not clear if this reverting is needed. While this behavior change is purely unintetional, whether its revert is needed is not a no brainer and needs team decision. It's highly suggested to merge AFTER that decision is made. This PR can be simply closed if it was decided a revert is not desirable.

citing myself on discord

> this is an __unintentional__ change and can be reverted at ease without breaking single use tool. however, I'm not sure if the behavior they want is desirable any more
> the encoded tool can either be single use tool or wrench, but not both. since ae2 probably cannot subsitute either for another (this is due to single use tool having only one oredict name, but typical crafting tool have 3 or more), once people realize how much single use tool can help ae2 performance, they will probably want to switch to single use tool. if we revert that change, then the default encoded tool will again not be what they want, i.e. they will complain again, that the encoded tool is not the single use variant