### PR TITLE
Add AAL batch mode

### DIFF
--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -802,7 +802,7 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
 
                     ItemStack firstItemSlot = getInputBusContent(0);
                     int recipesAvailable = Math.floorDiv(firstItemSlot.stackSize, recipe.mInputs[0].stackSize);
-                    int desiredBatches = (int) Math.ceil((float) BATCH_MODE_MIN_TICK_TIME / (float) timePerSlice);
+                    int desiredBatches = Math.floorDiv(BATCH_MODE_MIN_TICK_TIME, timePerSlice);
                     int parallel = Math.min(recipesAvailable, desiredBatches);
                     // We no longer need to check if we have enough items in the first slot, as this is
                     // guaranteed by taking the minimum earlier.

--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -404,7 +404,7 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
                     inputVoltage = aNBT.getLong("inputV");
                     inputEUt = aNBT.getLong("inputEU");
                     baseEUt = aNBT.getLong("baseEU");
-                    currentRecipeParallel= aNBT.getInteger("currentParallel");
+                    currentRecipeParallel = aNBT.getInteger("currentParallel");
                     if (inputVoltage <= 0 || inputEUt <= 0 || baseEUt >= 0) {
                         criticalStopMachine("ggfab.gui.advassline.shutdown.load.energy");
                         loadedStack = null;

--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -35,6 +35,7 @@ import net.glease.ggfab.GGConstants;
 import net.glease.ggfab.mui.ClickableTextWidget;
 import net.glease.ggfab.util.OverclockHelper;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -972,6 +973,19 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
 
     @Override
     public boolean supportsBatchMode() {
+        return true;
+    }
+
+    @Override
+    public boolean onWireCutterRightClick(ForgeDirection side, ForgeDirection wrenchingSide, EntityPlayer aPlayer,
+            float aX, float aY, float aZ) {
+        batchMode = !batchMode;
+        if (batchMode) {
+            GT_Utility.sendChatToPlayer(aPlayer, "Batch recipes");
+        } else {
+            GT_Utility.sendChatToPlayer(aPlayer, "Don't batch recipes");
+        }
+
         return true;
     }
 

--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -617,7 +617,7 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
                     // mode it can suddenly cause the AAL to get stuck because it thinks there are not enough
                     // items in the bus. I'm not quite sure how to get around this, even though it should not matter
                     // in practice since all AAL automation uses stocking buses instead of regular input buses.
-                    stuff = bus.getStackInSlot(0).copy();
+                    stuff = bus.getStackInSlot(0);
                 }
             }
             itemInputsCurTick[index] = stuff;

--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -185,7 +185,7 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
     private int currentInputLength;
     private String lastStopReason = "";
     private int currentRecipeParallel = 1;
-    private static final int BATCH_MODE_PARALLEL = 4;
+    private static final int BATCH_MODE_PARALLEL = 128;
 
     public MTE_AdvAssLine(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);

--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -594,7 +594,6 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
         }
 
         if (getBaseMetaTileEntity().isAllowedToWork()) {
-            // Do we need to include parallel in hasAllItems() here as well?
             if (hasAllItems(currentRecipe, this.currentRecipeParallel)
                     && hasAllFluids(currentRecipe, this.currentRecipeParallel)
                     && slices[0].start()) {
@@ -614,7 +613,11 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
             if (index < mInputBusses.size()) {
                 GT_MetaTileEntity_Hatch_InputBus bus = mInputBusses.get(index);
                 if (bus.isValid()) {
-                    stuff = bus.getStackInSlot(0);
+                    // This limits items extracted per slice to 64. Normally this is not an issue, but with batch
+                    // mode it can suddenly cause the AAL to get stuck because it thinks there are not enough
+                    // items in the bus. I'm not quite sure how to get around this, even though it should not matter
+                    // in practice since all AAL automation uses stocking buses instead of regular input buses.
+                    stuff = bus.getStackInSlot(0).copy();
                 }
             }
             itemInputsCurTick[index] = stuff;

--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -802,6 +802,11 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
 
                     ItemStack firstItemSlot = getInputBusContent(0);
                     int recipesAvailable = Math.floorDiv(firstItemSlot.stackSize, recipe.mInputs[0].stackSize);
+                    // Divide recipes available by the amount of slices in the recipe. This will prevent the AAL from
+                    // batching instead of parallelizing, which would make it effectively slower.
+                    recipesAvailable = Math.floorDiv(recipesAvailable, recipe.mInputs.length);
+                    // Sanity check to avoid this being zero when there is only one recipe available.
+                    recipesAvailable = Math.max(recipesAvailable, 1);
                     int desiredBatches = Math.floorDiv(BATCH_MODE_MIN_TICK_TIME, timePerSlice);
                     int parallel = Math.min(recipesAvailable, desiredBatches);
                     // We no longer need to check if we have enough items in the first slot, as this is

--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -979,13 +979,14 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
     @Override
     public boolean onWireCutterRightClick(ForgeDirection side, ForgeDirection wrenchingSide, EntityPlayer aPlayer,
             float aX, float aY, float aZ) {
-        batchMode = !batchMode;
-        if (batchMode) {
-            GT_Utility.sendChatToPlayer(aPlayer, "Batch recipes");
-        } else {
-            GT_Utility.sendChatToPlayer(aPlayer, "Don't batch recipes");
+        if (aPlayer.isSneaking()) {
+            batchMode = !batchMode;
+            if (batchMode) {
+                GT_Utility.sendChatToPlayer(aPlayer, "Batch recipes");
+            } else {
+                GT_Utility.sendChatToPlayer(aPlayer, "Don't batch recipes");
+            }
         }
-
         return true;
     }
 

--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -372,6 +372,7 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
             aNBT.setLong("inputV", inputVoltage);
             aNBT.setLong("inputEU", inputEUt);
             aNBT.setLong("baseEU", baseEUt);
+            aNBT.setInteger("currentParallel", currentRecipeParallel);
         }
     }
 
@@ -403,6 +404,7 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
                     inputVoltage = aNBT.getLong("inputV");
                     inputEUt = aNBT.getLong("inputEU");
                     baseEUt = aNBT.getLong("baseEU");
+                    currentRecipeParallel= aNBT.getInteger("currentParallel");
                     if (inputVoltage <= 0 || inputEUt <= 0 || baseEUt >= 0) {
                         criticalStopMachine("ggfab.gui.advassline.shutdown.load.energy");
                         loadedStack = null;


### PR DESCRIPTION
This PR adds support for batch mode to the AAL. A few notes:

- Similarly to regular batch mode, the amount of batches to run is chosen so the time of each slice is at least 128 ticks. If the time per slice is already 128 ticks, this does nothing.
- Batch size is also controlled by how many recipes we can do with the amount of the first item we have. If we want to run 10 batches but only have enough starting items for 5, it will run 5 batches.
- If there are not enough fluids to run multiple batches, it will not batch at all and simply process one recipe at a time.
- If a slice cannot extract enough materials to do a full batch, it gets stuck (similarly to a regular AAL).
- Currently, this only works well with stocking input buses, see the comment I left on line 616. I don't think this should be a problem since you will never use input buses with more than one slot to automate an AAL.

Short demo video (not yet using adaptive batch sizes)

https://streamable.com/hrp1v3