### PR TITLE
Syncing TextWidget

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.92:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.95:dev")
 
     testImplementation(platform('org.junit:junit-bom:5.8.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.77:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.92:dev")
 
     testImplementation(platform('org.junit:junit-bom:5.8.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.16'
 }
 
 

--- a/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
+++ b/src/main/java/net/glease/ggfab/mte/MTE_AdvAssLine.java
@@ -540,7 +540,7 @@ public class MTE_AdvAssLine extends GT_MetaTileEntity_ExtendedPowerMultiBlockBas
                 new TextWidget(Text.localised("ggfab.gui.advassline.shutdown"))
                         .setEnabled(this::hasAbnormalStopReason));
         screenElements.widget(
-                TextWidget.dynamicText(() -> Text.localised(lastStopReason)).setSynced(false)
+                new TextWidget().setTextSupplier(() -> Text.localised(lastStopReason))
                         .attachSyncer(
                                 new FakeSyncWidget.StringSyncer(() -> lastStopReason, r -> this.lastStopReason = r),
                                 screenElements)


### PR DESCRIPTION
* Replaces one instance where a dynamic text field is being communicated between server and client with a purely client-side method. In some cases this allows the client to do localization on these texts correctly. (See https://github.com/GTNewHorizons/ModularUI/pull/69.)

This is a part of the series of PRs implementing new ModularUI features, however this mod does not use any numeric text fields or similar, and thus no other changes are needed.